### PR TITLE
[ new ] Make count of theads be automatically used using `nproc` if can

### DIFF
--- a/src/Test/Golden/RunnerHelper.idr
+++ b/src/Test/Golden/RunnerHelper.idr
@@ -27,6 +27,15 @@ DefaultCmdUnderTest = MkCmdUnderTest "idris2"
 
 --- Options management ---
 
+nproc : IO $ Maybe Nat
+nproc = do
+  (str, 0) <- run "nproc"
+    | _ => pure Nothing
+  pure $ parsePositive str
+
+nproc' : IO Nat
+nproc' = fromMaybe 1 . filter (> 0) <$> nproc
+
 fitsPattern : (pattern, test : String) -> Bool
 fitsPattern = isInfixOf
 
@@ -39,6 +48,7 @@ testOptions = do
     , interactive := !((Just "true" /=) <$> getEnv "CI")
     , failureFile := Just "failures"
     , onlyNames := onlies <&> \patterns, test => any (`fitsPattern` test) patterns
+    , threads := !nproc'
     } (initOptions cmdUnderTest True)
 
 --- A universal way to set test pools from different origins ---


### PR DESCRIPTION
However, this may cause strange behaviour is the case when `pack` is used inside tests and they will install the same package simultaneously being run on different processors. My particular libraries which use this helper accidentally don't use this because both of them have the first test pool consisting with a single test, but still.