### PR TITLE
[ breaking ] Cleanup, remove deprecated `BaseTestsDir` interface

### DIFF
--- a/src/Test/Golden/RunnerHelper.idr
+++ b/src/Test/Golden/RunnerHelper.idr
@@ -12,13 +12,6 @@ import System.Directory
 
 --- Configuration facilities ---
 
--- Deprecated and to be removed in next versions
-public export
-interface BaseTestsDir where
-  constructor MkBaseTestsDir
-  %deprecate
-  baseTestsDir : String
-
 public export
 record BuildDir where
   constructor MkBuildDir


### PR DESCRIPTION
This will be merged as soon as existing project that declare their implementations of the `BaseTestsDir` interface will be removed